### PR TITLE
(very) minor fix in Doc

### DIFF
--- a/_sources/getting_started.txt
+++ b/_sources/getting_started.txt
@@ -70,7 +70,7 @@ Getting Boost
 =============
 
 :mod:`cpp-netlib` depends on Boost_.  It should work for any version
-of Boost above 1.41.0.  If Boost is not installed on your system, the
+of Boost above 1.43.0.  If Boost is not installed on your system, the
 latest package can be found on the `Boost web-site`_.  The environment
 variable ``BOOST_ROOT`` must be defined, which must be the full path
 name of the top directory of the Boost distribution.  Although Boost


### PR DESCRIPTION
Doc update: cpp-netlib Version 0.7 needs Boost-1.43 instead of Boost-1.41.
