### PR TITLE
add missing links to ProGit and GitHub Help Page

### DIFF
--- a/process.html
+++ b/process.html
@@ -70,10 +70,11 @@
               development workflow. If you need an introduction to git, please
               refer to the following links for git-specific information.</p>
               <ul>
-              <li><a href="">ProGit</a> &mdash; a website dedicated to basic
-              and advanced git usage.</li>
-              <li><a href="">GitHub Git Setup</a> &mdash; the GitHub help pages
-              on setting up git to work with GitHub.</li>
+              <li><a href="http://git-scm.com/book">ProGit</a> &mdash; a website 
+              dedicated to basic and advanced git usage.</li>
+              <li><a href="https://help.github.com/articles/set-up-git">GitHub 
+              Git Setup</a> &mdash; the GitHub help pages on setting up git 
+              to work with GitHub.</li>
               </ul>
               <p>What follows in this section assumes that you're already
               familiar with the basic git workflow.</p>


### PR DESCRIPTION
the href attributes were empty thus pointing to 
the displayed page, which is kind of irritating.
