### PR TITLE
Update links to GitHub releases

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,40 +53,24 @@
                         <div class="page-header">
                             <h1>Download</h1>
                         </div>
+                        <h2>Releases</h2>
+                        <div class="row">
+                            <div class="col-md-4">
+                                <a href="https://github.com/cpp-netlib/cpp-netlib/releases" class="btn btn-primary btn-lg btn-block">Releases</a>
+                                <br>
+                                <small class="text-muted">GitHub based releases.</small>
+                            </div>
+                        </div>
                         <h2>Stable</h2>
                         <div class="row">
                             <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.13.0/cpp-netlib-0.13.0-final.zip" class="btn btn-primary btn-lg btn-block">0.13.0-final (zip)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 11fc9ebe27dab21fb3663f6fa9f8699b</small>
-                            </div>
-                            <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.13.0/cpp-netlib-0.13.0-final.tar.gz" class="btn btn-primary btn-lg btn-block">0.13.0-final (tar.gz)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 002b0922bc7028d585c4975db748399d</small>
-                            </div>
-                            <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.13.0/cpp-netlib-0.13.0-final.tar.bz2" class="btn btn-primary btn-lg btn-block">0.13.0-final (tar.bz2)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 7933af08804db409f0a01f14fb997828</small>
+                                <a href="https://github.com/cpp-netlib/cpp-netlib/releases/tag/cpp-netlib-0.13.0-final" class="btn btn-primary btn-lg btn-block">0.13.0-final</a>
                             </div>
                         </div>
                         <h2>Previous Stable</h2>
                         <div class="row">
                             <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.12.0/cpp-netlib-0.12.0-final.zip" class="btn btn-success btn-lg btn-block">0.12.0-final (zip)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 19af754d82e0f3d3d67a456830a88861</small>
-                            </div>
-                            <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.12.0/cpp-netlib-0.12.0-final.tar.gz" class="btn btn-success btn-lg btn-block">0.12.0-final (tar.gz)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 29b87c0e8c1a9e7fbdea5afcec947d53</small>
-                            </div>
-                            <div class="col-md-4">
-                                <a href="http://downloads.cpp-netlib.org/0.12.0/cpp-netlib-0.12.0-final.tar.bz2" class="btn btn-success btn-lg btn-block">0.12.0-final (tar.bz2)</a>
-                                <br>
-                                <small class="text-muted cpp-netlib-hash">md5: 25d1a0bfa088ad4cede998c52fec7b91</small>
+                                <a href="https://github.com/cpp-netlib/cpp-netlib/releases/tag/cpp-netlib-0.12.0-final" class="btn btn-success btn-lg btn-block">0.12.0-final</a>
                             </div>
                         </div>
                     </section>


### PR DESCRIPTION
Use GitHub releases instead of externally hosted files.